### PR TITLE
Fix global name 'calendar' is not defined

### DIFF
--- a/resources/lib/common.py
+++ b/resources/lib/common.py
@@ -17,6 +17,7 @@ from string import capwords
 from time import mktime, sleep, strptime
 from uuid import UUID
 
+import calendar
 import xbmc
 import xbmcaddon
 import xbmcgui


### PR DESCRIPTION
In the function `utc2local` calendar might be used but not imported.